### PR TITLE
Update package name and fix fetch request formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Final-year-project",
+  "name": "code",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {}

--- a/phishing-sim/phishing-sim-ui/src/components/SendEmail.jsx
+++ b/phishing-sim/phishing-sim-ui/src/components/SendEmail.jsx
@@ -18,18 +18,14 @@ const SendEmail = () => {
     console.log("Sending email to:", email);
 
     try {
-      const response = await fetch(
-        `${API_BASE}/send-phishing-email`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ recipientEmail: email }),
+      const response = await fetch(`${API_BASE}/send-phishing-email`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
         },
         credentials: "include",
         body: JSON.stringify({ recipientEmail: email }),
-      );
+      });
 
       console.log("Send email response status:", response.status);
 


### PR DESCRIPTION
This pull request makes two changes:

1. Updates the package name in package-lock.json from "Final-year-project" to "code"

2. Refactors the fetch request in SendEmail.jsx:
   - Consolidates the fetch call formatting for better readability
   - Adds missing "credentials: include" option to the request
   - Removes duplicate body parameter (was specified twice)

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/715eae9bbc24428bbc5e1a8b1d37e31c/swoosh-den)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>715eae9bbc24428bbc5e1a8b1d37e31c</projectId>-->
<!--<branchName>swoosh-den</branchName>-->